### PR TITLE
v1.4.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "beans-rs"
-version = "1.4.2"
+version = "1.4.3"
 edition = "2021"
 authors = [
     "Adastral Group (https://adastral.net)",

--- a/src/ctx.rs
+++ b/src/ctx.rs
@@ -235,7 +235,7 @@ impl RunnerContext
                     error: e,
                     backtrace: Backtrace::capture()
                 };
-                trace!("[RunnerContext::extract_package] {:}\n{:#?}" xe, xe);
+                trace!("[RunnerContext::extract_package] {:}\n{:#?}", xe, xe);
                 sentry::capture_error(&xe);
                 return Err(xe);
             },

--- a/src/error.rs
+++ b/src/error.rs
@@ -25,19 +25,19 @@ pub enum BeansError
         location: String,
         error: std::io::Error
     },
-    #[error("Failed to extract {src_file} to directory {target_dir}")]
+    #[error("Failed to extract {src_file} to directory {target_dir} ({error:})")]
     TarExtractFailure {
         src_file: String,
         target_dir: String,
         error: std::io::Error,
         backtrace: Backtrace
     },
-    #[error("Failed to send request")]
+    #[error("Failed to send request ({error:})")]
     Reqwest {
         error: reqwest::Error,
         backtrace: Backtrace
     },
-    #[error("Failed to serialize or deserialize data")]
+    #[error("Failed to serialize or deserialize data ({error:})")]
     SerdeJson {
         error: serde_json::Error,
         backtrace: Backtrace
@@ -65,7 +65,7 @@ pub enum BeansError
         backtrace: Backtrace
     },
 
-    #[error("Failed to run the verify command with butler.")]
+    #[error("Failed to run the verify command with butler. ({error:})")]
     ButlerVerifyFailure {
         signature_url: String,
         gamedir: String,
@@ -118,7 +118,7 @@ pub enum BeansError
         error: serde_json::Error,
         instance: AdastralVersionFile
     },
-    #[error("Failed to parse the version in {old_location}. It's content was {old_content}")]
+    #[error("Failed to parse the version in {old_location}. It's content was {old_content} ({error:})")]
     VersionFileParseFailure {
         error: ParseIntError,
         old_location: String,

--- a/src/helper/mod.rs
+++ b/src/helper/mod.rs
@@ -417,7 +417,7 @@ pub fn restore_gameinfo(ctx: &mut RunnerContext, data: Vec<u8>) -> Result<(), Be
     }
     return Ok(());
 }
-const GITHUB_RELEASES_URL: &str = "https://api.github.com/repos/adastralgroup/beans-rs/releases/latest";
+const GITHUB_RELEASES_URL: &str = "https://api.github.com/repositories/805393469/releases/latest";
 #[derive(Clone, Debug, serde::Deserialize, serde::Serialize)]
 pub struct GithubReleaseItem
 {

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -24,8 +24,7 @@ impl CustomLogger {
             sentry: sentry_log::SentryLogger::new().filter(|md| match md.level() {
                 log::Level::Error => LogFilter::Exception,
                 log::Level::Warn => LogFilter::Event,
-                log::Level::Info | log::Level::Debug => LogFilter::Breadcrumb,
-                log::Level::Trace => LogFilter::Ignore,
+                log::Level::Info | log::Level::Debug | log::Level::Trace => LogFilter::Breadcrumb,
             })
         });
     }


### PR DESCRIPTION
## Changes since v1.4.2
- Capture trace logging as a breadcrumb so it gets captured by Sentry.
- Show error reason in all errors that have an error inside of it.
- Change the GitHub Release URL since the repo was transferred from [AdastralGroup](https://github.com/adastralgroup) to [ktwrd](https://github.com/ktwrd)