### PR TITLE
v1.4.5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "beans-rs"
-version = "1.4.4"
+version = "1.4.5"
 edition = "2021"
 authors = [
     "Kate Ward <kate@dariox.club>"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ lazy_static = "1.4.0"
 thread-id = "4.2.1"
 colored = "2.1.0"
 sentry-log = "0.34.0"
+chrono = "0.4.38"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 winconsole = { version = "0.11.1", features = ["window"] }

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Requirements
 - Rust Toolchain (nightly, only for building)
     - Recommended to use [rustup](https://rustup.rs/) to install.
 - x86-64/AMD64 Processor ([see notes](#notes-binaries))
+- OpenSSL v3 (also required on deployments)
 - **Following requirements are only required for testing**
 - Steam Installed
     - Source SDK Base 2013 Multiplayer ([install](steam://instal/243750))

--- a/src/workflows/update.rs
+++ b/src/workflows/update.rs
@@ -31,7 +31,6 @@ impl UpdateWorkflow
         };
 
         ctx.gameinfo_perms()?;
-        let gameinfo_backup = ctx.read_gameinfo_file()?;
 
         if helper::has_free_space(ctx.sourcemod_path.clone(), patch.clone().tempreq)? == false {
             println!("[UpdateWorkflow::wizard] Not enough free space! Requires {}", helper::format_size(patch.tempreq));
@@ -50,6 +49,8 @@ impl UpdateWorkflow
 
         let mod_dir_location = ctx.get_mod_location();
         let staging_dir_location = ctx.get_staging_location();
+
+        helper::backup_gameinfo(ctx)?;
 
         ctx.gameinfo_perms()?;
         info!("[UpdateWorkflow] Verifying game");
@@ -72,9 +73,6 @@ impl UpdateWorkflow
         }
 
         ctx.gameinfo_perms()?;
-        if let Some(gi) = gameinfo_backup {
-            helper::restore_gameinfo(ctx, gi)?;
-        }
 
         println!("Game has been updated!");
         Ok(())

--- a/src/workflows/verify.rs
+++ b/src/workflows/verify.rs
@@ -29,18 +29,14 @@ impl VerifyWorkflow {
             return Ok(());
         }
 
-        ctx.gameinfo_perms()?;
-        let gameinfo_backup = ctx.read_gameinfo_file()?;
+        helper::backup_gameinfo(ctx)?;
         let mod_dir_location = ctx.get_mod_location();
         butler::verify(
             format!("{}{}", &av.remote_info.base_url, remote.signature_url.unwrap()),
             mod_dir_location.clone(),
             format!("{}{}", &av.remote_info.base_url, remote.heal_url.unwrap()))?;
-        ctx.gameinfo_perms()?;
-        if let Some(gi) = gameinfo_backup {
-            helper::restore_gameinfo(ctx, gi)?;
-        }
         println!("[VerifyWorkflow::wizard] The verification process has completed, and any corruption has been repaired.");
+        ctx.gameinfo_perms()?;
         Ok(())
     }
 }


### PR DESCRIPTION
Minor bug fixes
# Changes since v1.4.4
- Remove `gameinfo.txt` restoring feature (after verify or update)
- `gameinfo.txt` will only be backed up, to the `gameinfo_backups` directory in the folder for your source mod.
- Added note in `README.md` about OpenSSL v3 being a runtime and development dependency (at the very least for Linux)

![screenshot](https://res.kate.pet/upload/b2d270d4ac7f/WindowsTerminal_B2ypJKcvP3.png)