### PR TITLE
Use ~/.tmp/ instead of /var/tmp/ on SteamOS

### DIFF
--- a/src/helper/mod.rs
+++ b/src/helper/mod.rs
@@ -364,7 +364,25 @@ pub fn format_size(i: usize) -> String {
 pub fn get_tmp_dir() -> String
 {
     let mut dir = std::env::temp_dir().to_str().unwrap_or("").to_string();
-    if cfg!(target_os = "android") {
+    if is_steamdeck() {
+        trace!("[helper::get_tmp_dir] Detected that we are running on a steam deck. Using ~/.tmp/beans-rs");
+        match simple_home_dir::home_dir() {
+            Some(v) => {
+                match v.to_str() {
+                    Some(k) => {
+                        dir = format_directory_path(k.to_string());
+                        dir = join_path(dir, String::from(".tmp"));
+                    },
+                    None => {
+                        trace!("[helper::get_tmp_dir] Failed to convert PathBuf to &str");
+                    }
+                }
+            },
+            None => {
+                trace!("[helper::get_tmp_dir] Failed to get home directory.");
+            }
+        };
+    } else if cfg!(target_os = "android") {
         dir = String::from("/data/var/tmp");
     } else if cfg!(not(target_os = "windows")) {
         dir = String::from("/var/tmp");

--- a/src/helper/mod.rs
+++ b/src/helper/mod.rs
@@ -1,4 +1,4 @@
-﻿#[cfg(not(target_os = "windows"))]
+#[cfg(not(target_os = "windows"))]
 mod linux;
 
 use std::backtrace::Backtrace;
@@ -171,6 +171,16 @@ pub fn join_path(tail: String, head: String) -> String
     }
 
     format!("{}{}", format_directory_path(tail), h)
+}
+pub fn remove_path_head(location: String) -> String
+{
+    let p = std::path::Path::new(&location);
+    if let Some(x) = p.parent() {
+        if let Some(m) = x.to_str() {
+            return m.to_string();
+        }
+    }
+    return String::new();
 }
 /// Make sure that the location provided is formatted as a directory (ends with `crate::PATH_SEP`).
 pub fn format_directory_path(location: String) -> String

--- a/src/helper/mod.rs
+++ b/src/helper/mod.rs
@@ -127,6 +127,14 @@ pub fn file_exists(location: String) -> bool
 {
     std::path::Path::new(&location).exists()
 }
+/// Check if the location provided exists and it's a directory.
+pub fn dir_exists(location: String) -> bool
+{
+    if file_exists(location.clone()) {
+        return is_directory(location.clone());
+    }
+    return false;
+}
 pub fn is_directory(location: String) -> bool
 {
     let x = PathBuf::from(&location);

--- a/src/helper/mod.rs
+++ b/src/helper/mod.rs
@@ -373,8 +373,9 @@ pub fn get_tmp_dir() -> String
     dir = join_path(dir, String::from("beans-rs"));
     dir = format_directory_path(dir);
 
-    if !file_exists(dir.clone()) {
+    if !dir_exists(dir.clone()) {
         if let Err(e) = std::fs::create_dir(&dir) {
+            trace!("[helper::get_tmp_dir] {:#?}", e);
             warn!("[helper::get_tmp_dir] failed to make tmp directory at {} ({:})", dir, e);
             sentry::capture_error(&e);
         } else {


### PR DESCRIPTION
On SteamOS, the `/var` mount is only given a small amount of space to work with, which can cause `beans-rs` to throw/return the error `FreeSpaceCheckFailure` to be returned.

This pull request adds the ability to detect if we are running on SteamOS, and if so, use `~/.tmp` as the temporary directory instead of `/var/tmp`.

This PR also adds the `dir_exists` and `is_steamdeck` functions to the `helper` module.