### PR TITLE
[linux] support checking free space on root drive

### DIFF
--- a/src/helper/mod.rs
+++ b/src/helper/mod.rs
@@ -251,7 +251,7 @@ pub fn get_free_space(location: String) -> Result<u64, BeansError>
     }
 
     let mut l = parse_location(location.clone());
-    while l.len() >= 2 {
+    while !l.is_empty() {
         debug!("[get_free_space] Checking if {} is in data", l);
         if let Some(x) = data.get(&l) {
             return Ok(x.clone());

--- a/src/helper/mod.rs
+++ b/src/helper/mod.rs
@@ -256,7 +256,7 @@ pub fn get_free_space(location: String) -> Result<u64, BeansError>
         if let Some(x) = data.get(&l) {
             return Ok(x.clone());
         }
-        l = remove_path_head(l.clone());
+        l = remove_path_head(l);
     }
 
     Err(BeansError::FreeSpaceCheckFailure {


### PR DESCRIPTION
`/var/tmp/beans-rs` is stored on `/` on my system so the check keeps removing paths until we end up with `/` which is shorter than 2 causing a check failure.

Checking if its empty should be better.


Also removes the needless clone, transfering ownership when `remove_path_head` is invoked, since it allocates a new string.