### PR TITLE
v1.5.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "beans-rs"
-version = "1.5.1"
+version = "1.5.2"
 edition = "2021"
 authors = [
     "Kate Ward <kate@dariox.club>"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "beans-rs"
-version = "1.5.0"
+version = "1.5.1"
 edition = "2021"
 authors = [
     "Kate Ward <kate@dariox.club>"

--- a/src/helper/mod.rs
+++ b/src/helper/mod.rs
@@ -408,7 +408,6 @@ pub fn get_tmp_dir() -> String
         if let Err(e) = std::fs::create_dir(&dir) {
             trace!("[helper::get_tmp_dir] {:#?}", e);
             warn!("[helper::get_tmp_dir] failed to make tmp directory at {} ({:})", dir, e);
-            return;
         }
     }
     dir = join_path(dir, String::from("beans-rs"));


### PR DESCRIPTION
- Merged #24 
	- Fixed `get_free_space` failing when the provided location is on a mount point that has a length less than `2`.
- Merged #27 
	- A custom temporary directory can now be defined with the environment variable `ADASTRAL_TMPDIR` (must already exist for this to work).
- Bumped version to v1.5.2