### PR TITLE
Updated post-install text due to Source SDK update

### DIFF
--- a/src/text/install_complete_linux.txt
+++ b/src/text/install_complete_linux.txt
@@ -1,9 +1,10 @@
 
 Done! Make sure that the following is done;
   1. Install Source SDK Base 2013 Multiplayer on Steam
-  2. Install Team Fortress 2
-  3. Restart Steam
-  4. Play $MOD_NAME_STYLIZED
+  2. Use the "prerelease2021" branch for Source SDK Base 2013 Multiplayer
+  3. Install Team Fortress 2
+  4. Restart Steam
+  5. Play $MOD_NAME_STYLIZED
 
 -- Important --
-Make sure that Proton is enabled for Source SDK Base 2013 Multiplayer!
+Make sure that Proton Experimental is enabled for Source SDK Base 2013 Multiplayer!

--- a/src/text/install_complete_linux.txt
+++ b/src/text/install_complete_linux.txt
@@ -1,7 +1,7 @@
 
 Done! Make sure that the following is done;
   1. Install Source SDK Base 2013 Multiplayer on Steam
-  2. Use the "prerelease2021" branch for Source SDK Base 2013 Multiplayer
+  2. Use the "previous2021" branch for Source SDK Base 2013 Multiplayer
   3. Install Team Fortress 2
   4. Restart Steam
   5. Play $MOD_NAME_STYLIZED

--- a/src/text/install_complete_windows.txt
+++ b/src/text/install_complete_windows.txt
@@ -1,6 +1,7 @@
 
 Done! Make sure that the following is done;
   1. Install Source SDK Base 2013 Multiplayer on Steam
-  2. Install Team Fortress 2
-  3. Restart Steam
-  4. Play $MOD_NAME_STYLIZED
+  2. Use the "prerelease2021" branch for Source SDK Base 2013 Multiplayer
+  3. Install Team Fortress 2
+  4. Restart Steam
+  5. Play $MOD_NAME_STYLIZED

--- a/src/text/install_complete_windows.txt
+++ b/src/text/install_complete_windows.txt
@@ -1,7 +1,7 @@
 
 Done! Make sure that the following is done;
   1. Install Source SDK Base 2013 Multiplayer on Steam
-  2. Use the "prerelease2021" branch for Source SDK Base 2013 Multiplayer
+  2. Use the "previous2021" branch for Source SDK Base 2013 Multiplayer
   3. Install Team Fortress 2
   4. Restart Steam
   5. Play $MOD_NAME_STYLIZED


### PR DESCRIPTION
Updated the post-install completion text to tell the user to use the "previous2021" branch due to changes that (currently) break Open Fortress on the current branch ([build 17413218](https://steamdb.info/patchnotes/17413218/)).