### PR TITLE
v1.7.3

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
             filename: 'beans-rs'
             target: x86_64-unknown-linux-gnu
           - os: windows-latest
@@ -25,7 +25,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install Build Dependencies (ubuntu)
-        if: ${{ matrix.os == 'ubuntu-20.04' }}
+        if: ${{ matrix.os == 'ubuntu-22.04' }}
         run: |
           sudo apt-get update;
           sudo apt-get install -y \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
             filename: 'beans-rs'
             target: x86_64-unknown-linux-gnu
 
@@ -26,7 +26,7 @@ jobs:
     steps:
       - uses: actions/checkout@master
       - name: Install Build Dependencies (ubuntu)
-        if: ${{ matrix.os == 'ubuntu-20.04' }}
+        if: ${{ matrix.os == 'ubuntu-22.04' }}
         run: |
           sudo apt-get update;
           sudo apt-get install -y \

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,10 +16,10 @@ const_format = "0.2.34"
 futures = "0.3.31"
 futures-util = "0.3.31"
 indicatif = "0.17.11"
-rand = "0.9.0"
+rand = "0.9.1"
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.140"
-sysinfo = "0.33.1"
+sysinfo = "0.35.1"
 tar = "0.4.44"
 tokio-util = { version= "0.7.14", features = ["io"] }
 zstd = "0.13.3"
@@ -32,7 +32,7 @@ log = "0.4.26"
 lazy_static = "1.5.0"
 thread-id = "5.0.0"
 colored = "3.0.0"
-sentry-log = "0.36.0"
+sentry-log = "0.38.0"
 chrono = "0.4.40"
 
 fltk = { version = "1.5.4" }
@@ -49,7 +49,7 @@ winreg = "0.55.0"
 dunce = "1.0.5"
 
 [dependencies.sentry]
-version = "0.36.0"
+version = "0.38.0"
 default-features = false
 features = [
     "backtrace",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,8 @@ fl2rust = "0.7.0"
 [target.'cfg(target_os = "windows")'.dependencies]
 winconsole = { version = "0.11.1", features = ["window"] }
 winreg = "0.55.0"
+widestring = "1.1.0"
+windows = { version = "0.60.0", features = ["Win32_System_IO", "Win32_Storage_FileSystem"] }
 dunce = "1.0.5"
 
 [dependencies.sentry]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,10 @@
 [package]
 name = "beans-rs"
-version = "1.7.2"
+version = "1.7.3"
 edition = "2021"
 authors = [
-    "Kate Ward <kate@dariox.club>"
+    "Kate Ward <kate@dariox.club>",
+    "ToastXC <contact@toastxc.xyz>"
 ]
 description = "Installer for Open Fortress"
 repository = "https://github.com/ktwrd/beans-rs"

--- a/src/aria2.rs
+++ b/src/aria2.rs
@@ -69,14 +69,20 @@ pub async fn download_file(
             .replace("%OUT_FILENAME%", &output_filename)
             .replace("%USER_AGENT%", &user_agent)
             .replace("%URL%", &url);
-        debug!("[aria2::download_file] using customized arguments: {}", repl);
+        debug!(
+            "[aria2::download_file] using customized arguments: {}",
+            repl
+        );
         cmd.arg(repl);
     }
     else
     {
         if let Some(extra) = crate::env_aria2c_extra_args()
         {
-            debug!("[aria2::download_file] (prepend) extra arguments: {}", extra);
+            debug!(
+                "[aria2::download_file] (prepend) extra arguments: {}",
+                extra
+            );
             cmd.arg(extra);
         }
         cmd.args([

--- a/src/error.rs
+++ b/src/error.rs
@@ -227,6 +227,23 @@ pub enum BeansError
         reason: Aria2cExitCodeReason,
         cmd: String,
         backtrace: Backtrace
+    },
+
+    #[error("Failed to read file attributes on {location} ({error:})")]
+    ReadFileAttributesError
+    {
+        error: std::io::Error,
+        location: String,
+        backtrace: Backtrace
+    },
+
+    #[error("Failed to set file attributes on {location} ({hresult:#010x}, {hresult_msg:})")]
+    WindowsSetFileAttributeError
+    {
+        hresult: i32,
+        hresult_msg: String,
+        location: String,
+        backtrace: Backtrace
     }
 }
 #[derive(Debug)]

--- a/src/extract.rs
+++ b/src/extract.rs
@@ -5,10 +5,12 @@ use indicatif::{ProgressBar,
                 ProgressStyle};
 use log::{debug,
           error,
-          info};
+          info,
+          warn};
 use zstd::stream::read::Decoder as ZstdDecoder;
 
-use crate::BeansError;
+use crate::{helper::join_path,
+            BeansError};
 
 fn unpack_tarball_getfile(
     tarball_location: String,
@@ -69,6 +71,7 @@ pub fn unpack_tarball(
     tarball = unpack_tarball_getfile(tarball_location.clone(), output_directory.clone())?;
     archive = tar::Archive::new(&tarball);
     archive.set_preserve_permissions(false);
+    archive.set_preserve_ownerships(false);
 
     let pb = ProgressBar::new(archive_entry_count);
     pb.set_style(ProgressStyle::with_template("{msg}\n{spinner:.green} [{elapsed_precise}] [{wide_bar:.cyan/blue}] {pos}/{len} ({eta})")
@@ -98,6 +101,7 @@ pub fn unpack_tarball(
         {
             Ok(mut x) =>
             {
+                x.set_preserve_permissions(false);
                 pb.set_message("Extracting files");
                 let mut filename = String::new();
 

--- a/src/extract.rs
+++ b/src/extract.rs
@@ -154,6 +154,21 @@ pub fn unpack_tarball(
                         });
                     }
                 }
+
+                if let Ok(entry_path) = x.path()
+                {
+                    if let Some(ep_str) = entry_path.to_str()
+                    {
+                        let ep = ep_str.to_string();
+                        let target_path = join_path(output_directory.clone(), ep);
+                        if crate::helper::file_exists(target_path.clone())
+                        {
+                            if let Err(e) = crate::helper::unmark_readonly(target_path.clone())
+                            {
+                                debug!("Failed to unmark read-only on file: {target_path:} {e:#?}");
+                            }
+                        }
+                    }
                 }
                 pb.inc(1);
             }

--- a/src/extract.rs
+++ b/src/extract.rs
@@ -109,6 +109,19 @@ pub fn unpack_tarball(
                         filename = String::from(s);
                     }
                 }
+
+                if filename.len() == 0
+                {
+                    if let Ok(entry_path) = x.path()
+                    {
+                        if let Some(ep_str) = entry_path.to_str()
+                        {
+                            let ep = ep_str.to_string();
+                            filename = ep;
+                        }
+                    }
+                }
+
                 if let Err(error) = x.unpack_in(&output_directory)
                 {
                     debug!("error={:#?}", error);

--- a/src/helper/linux.rs
+++ b/src/helper/linux.rs
@@ -85,3 +85,11 @@ fn find_steam_reg_path() -> Result<String, BeansError>
     error!("Couldn't find any of the locations in STEAM_POSSIBLE_DIR");
     Err(BeansError::SteamNotFound)
 }
+
+pub fn unmark_readonly(location: String) -> Result<(), BeansError>
+{
+    // does nothing since this function only
+    // matters for windows
+    // -kate, 13th mar 2025
+    Ok(())
+}

--- a/src/helper/windows.rs
+++ b/src/helper/windows.rs
@@ -1,5 +1,12 @@
-use std::backtrace::Backtrace;
+use std::{backtrace::Backtrace,
+          ffi::OsStr,
+          os::windows::fs::MetadataExt};
 
+use bitflags::bitflags;
+use log::debug;
+use widestring::U16String;
+use windows::{core::PCWSTR,
+              Win32::Storage::FileSystem::*};
 use winreg::{enums::HKEY_CURRENT_USER,
              RegKey};
 
@@ -32,5 +39,119 @@ pub fn find_sourcemod_path() -> Result<String, BeansError>
             error: e,
             backtrace: Backtrace::capture()
         })
+    }
+}
+
+/// Unmark a file as readonly. For some reason, `gameinfo.txt` is always
+/// readonly, and trying to replace it fails. Unmarking it when this function
+/// when extracting should fix the issue.
+pub fn unmark_readonly(location: String) -> Result<(), BeansError>
+{
+    if !crate::helper::file_exists(location.clone())
+    {
+        debug!("[windows::unmark_readonly] file does not exist: {location:}");
+        return Ok(());
+    }
+
+    let s = location.as_str();
+    let previous = match get_windows_file_attributes(&s)
+    {
+        Ok(a) => a,
+        Err(e) =>
+        {
+            return Err(BeansError::ReadFileAttributesError {
+                error: e,
+                location: s.to_string(),
+                backtrace: Backtrace::capture()
+            });
+        }
+    };
+
+    if !previous.contains(WindowsFileAttribute::ReadOnly)
+    {
+        return Ok(());
+    }
+
+    let mut new_attr = previous - WindowsFileAttribute::ReadOnly;
+    if new_attr.contains(WindowsFileAttribute::Archive)
+    {
+        new_attr -= WindowsFileAttribute::Archive;
+    }
+
+    if new_attr.is_empty()
+    {
+        new_attr = WindowsFileAttribute::Normal;
+    }
+
+    match set_file_attributes_win(&s, new_attr)
+    {
+        Ok(_) => Ok(()),
+        Err(e) =>
+        {
+            let hr = e.code().0;
+            debug!("file.name={s}");
+            debug!("file.attr={new_attr:#?}");
+            Err(BeansError::WindowsSetFileAttributeError {
+                hresult: hr,
+                hresult_msg: e.message(),
+                location: s.to_string(),
+                backtrace: Backtrace::capture()
+            })
+        }
+    }
+}
+
+fn set_file_attributes_win<P: AsRef<OsStr>>(
+    location: P,
+    attr: WindowsFileAttribute
+) -> windows::core::Result<()>
+{
+    if let Some(location_str) = location.as_ref().to_str()
+    {
+        if crate::helper::file_exists(format!("{location_str}"))
+        {
+            let s = U16String::from_str(location_str);
+            let mut a = attr.clone();
+            if a.is_empty()
+            {
+                a = WindowsFileAttribute::Normal;
+            }
+            let win32_attr = FILE_FLAGS_AND_ATTRIBUTES(a.bits());
+            unsafe {
+                let win32_loc = PCWSTR(s.as_ptr());
+                SetFileAttributesW(win32_loc, win32_attr)?;
+            }
+        }
+    }
+    Ok(())
+}
+
+fn get_windows_file_attributes<P: AsRef<std::path::Path>>(
+    location: &P
+) -> std::io::Result<WindowsFileAttribute>
+{
+    let metadata = std::fs::metadata(location)?;
+    let attr = metadata.file_attributes();
+    if let Some(flags) = WindowsFileAttribute::from_bits(attr)
+    {
+        return Ok(flags);
+    }
+    else
+    {
+        return Ok(WindowsFileAttribute::empty());
+    }
+}
+
+bitflags! {
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+    pub struct WindowsFileAttribute : u32 {
+        const ReadOnly = 1;
+        const Hidden = 2;
+        const System = 4;
+        const Archive = 32;
+        const Normal = 128;
+        const Temporary = 256;
+        const Offline = 4096;
+        const NonContentIndexed = 8192;
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -103,9 +103,10 @@ pub fn env_disable_aria2c() -> bool
 /// if they exist and there is at least 1 character in it;
 /// - `BEANS_ARIA2C_ARGS_OVERRIDE`
 /// - `ADASTRAL_ARIA2C_ARGS_OVERRIDE`
-/// 
-/// This string will be used as the launch arguments for aria2c. It'll replace the following content with;
-/// 
+///
+/// This string will be used as the launch arguments for aria2c. It'll replace
+/// the following content with;
+///
 /// | Look For | Replace With |
 /// | -------- | ------------ |
 /// | `%OUT_DIR%` | Output directory (argument `-d` with aria2c) |
@@ -135,8 +136,9 @@ pub fn env_aria2c_override_args() -> Option<String>
 /// if they exist and there is at least 1 character in it;
 /// - `BEANS_ARIA2C_ARGS`
 /// - `ADASTRAL_ARIA2C_ARGS`
-/// 
-/// This string will be put in the launch argument for starting the aria2c instance.
+///
+/// This string will be put in the launch argument for starting the aria2c
+/// instance.
 pub fn env_aria2c_extra_args() -> Option<String>
 {
     if let Some(val) = helper::try_get_env_var("BEANS_ARIA2C_ARGS".to_string())


### PR DESCRIPTION
- Updated dependencies
- Log warning when tar entry fails to extract ONLY when the error is PermissionDenied (just checked if the debug formatted error contained some strings, too lazy to properly implement atm)
- Try to unmark files as read-only after extracted from tarball.